### PR TITLE
Fixed SelectTypeParameters in slurm.conf

### DIFF
--- a/pywps-scheduler-demo/slurm/slurm.conf
+++ b/pywps-scheduler-demo/slurm/slurm.conf
@@ -99,7 +99,7 @@ FastSchedule=1
 SchedulerType=sched/builtin
 SchedulerPort=7321
 SelectType=select/cons_res
-#SelectTypeParameters=
+SelectTypeParameters=CR_CPU
 #
 #
 # JOB PRIORITY


### PR DESCRIPTION
SelectTypeParameters's default value must explicitly be set in some versions of SLURM (bug?)